### PR TITLE
fix(src/metadata.rs): remove unused std::fs::File import

### DIFF
--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -16,7 +16,6 @@
 
 use crate::ImagePair;
 use anyhow::Result;
-use std::fs::File;
 use std::io::{BufWriter, Write};
 use std::path::Path;
 


### PR DESCRIPTION
Unused import promoted to compile error by `RUSTFLAGS=-Dwarnings` on test + coverage jobs, blocking every Dependabot PR. `rg` confirms `File` is referenced nowhere else in the file.