### PR TITLE
style: apply cargo fmt to unblock test job

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,11 @@ pub struct ImagePair {
 
 impl ImagePair {
     /// Construct a new `ImagePair` from the given paths and original file size.
-    pub fn new(original: impl Into<String>, decoded: impl Into<String>, original_size: u64) -> Self {
+    pub fn new(
+        original: impl Into<String>,
+        decoded: impl Into<String>,
+        original_size: u64,
+    ) -> Self {
         Self {
             original: original.into(),
             decoded: decoded.into(),
@@ -138,7 +142,14 @@ pub fn assign_split_by_index(index: usize, total: usize) -> Split {
 ///
 /// The partition is deterministic given a pre-ordered (e.g. shuffled) slice.
 /// Returns `(train, test, val, calibration)`.
-pub fn partition_pairs(pairs: &[ImagePair]) -> (Vec<&ImagePair>, Vec<&ImagePair>, Vec<&ImagePair>, Vec<&ImagePair>) {
+pub fn partition_pairs(
+    pairs: &[ImagePair],
+) -> (
+    Vec<&ImagePair>,
+    Vec<&ImagePair>,
+    Vec<&ImagePair>,
+    Vec<&ImagePair>,
+) {
     let total = pairs.len();
     let mut train = Vec::new();
     let mut test = Vec::new();

--- a/tests/smoke_test.rs
+++ b/tests/smoke_test.rs
@@ -75,7 +75,11 @@ fn split_all_contains_four_unique_variants() {
     // Verify there are no duplicates by comparing hash-equality.
     use std::collections::HashSet;
     let set: HashSet<_> = all.iter().collect();
-    assert_eq!(set.len(), 4, "Split::all() must not contain duplicate variants");
+    assert_eq!(
+        set.len(),
+        4,
+        "Split::all() must not contain duplicate variants"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -213,7 +217,10 @@ fn assign_split_by_index_single_item_documented_behaviour() {
     let split = assign_split_by_index(0, 1);
     // Must be a valid variant (no panic or undefined behaviour).
     assert!(
-        matches!(split, Split::Train | Split::Test | Split::Val | Split::Calibration),
+        matches!(
+            split,
+            Split::Train | Split::Test | Split::Val | Split::Calibration
+        ),
         "must return a valid Split for single-item dataset"
     );
 }
@@ -236,7 +243,13 @@ fn partition_pairs_empty_slice_produces_empty_vecs() {
 #[test]
 fn partition_pairs_total_count_equals_input_length() {
     let pairs: Vec<ImagePair> = (0..200)
-        .map(|i| ImagePair::new(format!("orig/{}.png", i), format!("dec/{}.png", i), i as u64 * 1024))
+        .map(|i| {
+            ImagePair::new(
+                format!("orig/{}.png", i),
+                format!("dec/{}.png", i),
+                i as u64 * 1024,
+            )
+        })
         .collect();
 
     let (train, test, val, calibration) = partition_pairs(&pairs);


### PR DESCRIPTION
## Why

`cargo fmt --check` is failing in the `test` job of `rust-ci.yml`, which blocks every Dependabot PR. RUSTFLAGS=-Dwarnings + fmt-check-strict means the workflow rejects any unformatted code.

## What

Replays the exact rustfmt output captured from the failing CI log on PR #22. Five reformats:

- `src/lib.rs:77` — `ImagePair::new()` signature wrapped
- `src/lib.rs:138` — `partition_pairs()` signature + return tuple wrapped
- `tests/smoke_test.rs:75` — `assert_eq!()` wrapped
- `tests/smoke_test.rs:213` — `matches!()` wrapped
- `tests/smoke_test.rs:236` — `.map(|i| ImagePair::new(...))` wrapped to multi-line block

No semantic changes; only whitespace.

## Verify

The test job's `cargo fmt --check` step should now pass. If rustfmt picks up any additional whitespace differences I missed, CI will tell us and we iterate.