### PR TITLE
chore(scorecard): align schedule to canonical weekly ('23 4 * * 1')

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main, master]
   schedule:
-    - cron: '0 4 * * *'
+    - cron: '23 4 * * 1'
   workflow_dispatch:
 
 # Estate guardrail: cancel superseded runs so re-pushes / rebased PR


### PR DESCRIPTION
Cut 2 of the GH Actions budget rebalancing plan (2026-05-27).

Aligns with standards canonical and [standards#230](https://github.com/hyperpolymath/standards/pull/230) (reusable example fix, MERGED). Tracking: [standards#231](https://github.com/hyperpolymath/standards/issues/231).

Single-line cron change. Comment-equivalent doc shape — no behaviour change to the workflow logic, only frequency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)