### PR TITLE
ci: repin orphan reusable SHAs (97df7621/4fdf4314 → live)

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   rust-ci:
-    uses: hyperpolymath/standards/.github/workflows/rust-ci-reusable.yml@4fdf4314b4ab54269adbaff10e30e483b5e86845
+    uses: hyperpolymath/standards/.github/workflows/rust-ci-reusable.yml@cc5a372af1af1b202c17f1b21efd954e6c038bef
     with:
       enable_audit: true
       enable_coverage: true


### PR DESCRIPTION
## Summary

The workflow(s) in this repo pinned `hyperpolymath/standards` reusable workflow(s) at orphan SHAs — commits no longer reachable from `standards/main`. The Contents API resolves the blob (cached lookup), so code-review tooling does not catch this, but `workflow_call` at run-time refuses orphan SHAs and emits "workflow file issue" with zero jobs created.

## Fix

Re-pin to the reachable merge-commit SHAs:
- `hypatia-scan-reusable.yml@97df7621` → `@915139d73560e65a8240b8fc7768698658502c89`
- `rust-ci-reusable.yml@4fdf4314` → `@cc5a372af1af1b202c17f1b21efd954e6c038bef`

(only the reusables actually pinned in this repo are touched)

## Reference

- Audit: hyperpolymath/standards/docs/audits/audit-hypatia-pin-orphan-2026-05-27.adoc
- Detector: hypatia rule WF016 (`Hypatia.Rules.WorkflowAudit.check_orphan_standards_reusable_pin`, hyperpolymath/hypatia#393)

## Estate-wide context

One of ~167 affected repos. Caught by the 2026-05-30 estate CI/CD audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)