### PR TITLE
ci: bump a2ml-validate-action to 6bff6ec (s-expression form support)

### DIFF
--- a/.github/workflows/dogfood-gate.yml
+++ b/.github/workflows/dogfood-gate.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Validate A2ML manifests
         if: steps.detect.outputs.count > 0
-        uses: hyperpolymath/a2ml-validate-action@59145c7d1039fa3059b3ecacdb50ee23d7505898 # main
+        uses: hyperpolymath/a2ml-validate-action@6bff6ec134fc977e86d25166a5c522ddea5c1e78 # main
         with:
           path: '.'
           strict: 'false'


### PR DESCRIPTION
Bump `hyperpolymath/a2ml-validate-action` from `59145c7` to `6bff6ec`.

Upstream PR: hyperpolymath/a2ml-validate-action#26 (merged 2026-06-01) — validator now recognises both TOML and s-expression identity/version dialects.

Real-world bite: panic-attack#94 hit this on `docs/campaigns/2026-05-26.a2ml` on 2026-06-01.

Estate sweep: 215 repos in the same wave. No behavioural change unless the repo carries an s-expression-form `.a2ml` file.