### PR TITLE
chore(license): PMPL → MPL-2.0 sweep (9 files)

### DIFF
--- a/.clusterfuzzlite/Containerfile
+++ b/.clusterfuzzlite/Containerfile
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: PMPL-1.0
+# SPDX-License-Identifier: MPL-2.0
 FROM gcr.io/oss-fuzz-base/base-builder-rust@sha256:73c1d5648db54100639339d411a5d192cbc8bf413ee91e843a07cf6f0e319dc7
 
 COPY . $SRC/zerostep

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -eu
-# SPDX-License-Identifier: PMPL-1.0
+# SPDX-License-Identifier: MPL-2.0
 cd $SRC/zerostep
 cargo +nightly fuzz build
 for target in $(cargo +nightly fuzz list); do

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: PMPL-1.0
+# SPDX-License-Identifier: MPL-2.0
 name: OSSF Scorecard
 on:
   push:

--- a/.github/workflows/secret-scanner.yml
+++ b/.github/workflows/secret-scanner.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: PMPL-1.0
+# SPDX-License-Identifier: MPL-2.0
 # Prevention workflow - scans for hardcoded secrets before they reach main
 name: Secret Scanner
 

--- a/NOTICE
+++ b/NOTICE
@@ -2,21 +2,11 @@ Licensing Notice
 ================
 
 This project is authored by Jonathan D.A. Jewell (hyperpolymath) and
-is licensed under the Palimpsest License (MPL-2.0).
+is licensed under the Mozilla Public License 2.0 (MPL-2.0).
 
-The MPL-2.0 is a philosophical extension of the Mozilla Public
-License 2.0, adding provisions for cryptographic provenance, emotional
-lineage preservation, and quantum-safe signatures. The full PMPL text is
-available in LICENSES/MPL-2.0.txt.
+Per the estate license policy, this is a sole-owner repository and
+uses MPL-2.0 throughout — LICENSE file, package metadata, and all
+SPDX-License-Identifier source-file headers.
 
-For compatibility with automated license detection tools and platforms
-that require OSI-approved licenses, the root LICENSE file contains the
-standard Mozilla Public License 2.0 text. This ensures that package
-registries, CI systems, and other tooling correctly identify the license.
-
-The legally binding terms are:
-  - Source files: governed by MPL-2.0 (per SPDX headers)
-  - Combined works: compatible with MPL-2.0 (per PMPL Section 6)
-
-For more information about the Palimpsest License:
-  https://github.com/hyperpolymath/palimpsest-license
+For the MPL-2.0 license:
+  https://www.mozilla.org/en-US/MPL/2.0/

--- a/RSR_OUTLINE.adoc
+++ b/RSR_OUTLINE.adoc
@@ -209,7 +209,7 @@ This template is part of:
 
 == License
 
-SPDX-License-Identifier: MPL-2.0-or-later
+SPDX-License-Identifier: MPL-2.0
 
 == Links
 

--- a/fuzz/fuzz_targets/fuzz_input.rs
+++ b/fuzz/fuzz_targets/fuzz_input.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: PMPL-1.0
+// SPDX-License-Identifier: MPL-2.0
 //! Generic fuzz target for arbitrary input processing
 
 #![no_main]

--- a/vae-normalizer/LICENSES/GPL-3.0-or-later.txt
+++ b/vae-normalizer/LICENSES/GPL-3.0-or-later.txt
@@ -1,4 +1,4 @@
-SPDX-License-Identifier: MPL-2.0-or-later
+SPDX-License-Identifier: MPL-2.0
 
 GNU GENERAL PUBLIC LICENSE
 Version 3, 29 June 2007

--- a/vae-normalizer/LICENSES/LicenseRef-Palimpsest.txt
+++ b/vae-normalizer/LICENSES/LicenseRef-Palimpsest.txt
@@ -1,4 +1,4 @@
-SPDX-License-Identifier: MPL-2.0-or-later
+SPDX-License-Identifier: MPL-2.0
 
 PALIMPSEST LICENSE
 Version 0.8

--- a/vae-normalizer/LICENSES/MIT.txt
+++ b/vae-normalizer/LICENSES/MIT.txt
@@ -1,4 +1,4 @@
-SPDX-License-Identifier: MPL-2.0-or-later
+SPDX-License-Identifier: MPL-2.0
 
 MIT License
 


### PR DESCRIPTION
Sole-owner repo. Per the 2026-06-02 canonical license policy, PMPL is restricted to palimpsest-license / palimpsest-plasma / consent-aware-http; this repo gets MPL-2.0.

Files: 9 SPDX headers flipped + NOTICE rewrite (if applicable) + orphan PMPL license file delete (if applicable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)