### PR TITLE
ci(codeql): cron weekly→monthly (cut 3, standards#288)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
     branches: [main, master]
   schedule:
-    - cron: '0 6 * * 1'
+    - cron: '0 6 1 * *'   # monthly 1st 06:00 UTC
 
 # Estate guardrail: cancel superseded runs so re-pushes / rebased PR
 # updates do not pile up queued runs against the shared account-wide


### PR DESCRIPTION
Per standards#286 canonical (cut 3, Option B). PR-trigger runs unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)