### PR TITLE
chore(license): align Cargo.toml license field to LICENSE (MIT → MPL-2.0)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "1.0.0"
 edition = "2021"
 authors = ["Joshua Jewell"]
 description = "VAE dataset normalizer with formal verification and cryptographic integrity"
-license = "MIT"
+license = "MPL-2.0"
 repository = "https://huggingface.co/datasets/joshuajewell/VAEDecodedImages-SDXL"
 
 [lib]


### PR DESCRIPTION
Closes #51.